### PR TITLE
Add RefreshMode and Times to Java Gateway

### DIFF
--- a/saic-java-mqtt-gateway/pom.xml
+++ b/saic-java-mqtt-gateway/pom.xml
@@ -88,6 +88,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.36</version>

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayException.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayException.java
@@ -1,0 +1,11 @@
+package net.heberling.ismart.mqtt;
+
+public class MqttGatewayException extends RuntimeException {
+  public MqttGatewayException(String s) {
+    super(s);
+  }
+
+  public MqttGatewayException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayTopics.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayTopics.java
@@ -44,8 +44,8 @@ public class MqttGatewayTopics {
   public static final String REFRESH_LAST_VEHICLE_STATE = REFRESH + "/lastVehicleState";
   public static final String REFRESH_MODE = REFRESH + "/mode";
   public static final String REFRESH_PERIOD_ACTIVE = REFRESH + "/period/active";
-  public static final String REFRESH_PERIOD_AFTER_SHUTDOWN = REFRESH + "/period/afterShutdown";
   public static final String REFRESH_PERIOD_INACTIVE = REFRESH + "/period/inActive";
+  public static final String REFRESH_PERIOD_INACTIVE_GRACE = REFRESH + "/period/inActiveGrace";
   public static final String TYRES = "tyres";
   public static final String TYRES_FRONT_LEFT_PRESSURE = TYRES + "/frontLeftPressure";
   public static final String TYRES_FRONT_RIGHT_PRESSURE = TYRES + "/frontRightPressure";

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayTopics.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/MqttGatewayTopics.java
@@ -42,6 +42,10 @@ public class MqttGatewayTopics {
   public static final String REFRESH_LAST_ACTIVITY = REFRESH + "/lastActivity";
   public static final String REFRESH_LAST_CHARGE_STATE = REFRESH + "/lastChargeState";
   public static final String REFRESH_LAST_VEHICLE_STATE = REFRESH + "/lastVehicleState";
+  public static final String REFRESH_MODE = REFRESH + "/mode";
+  public static final String REFRESH_PERIOD_ACTIVE = REFRESH + "/period/active";
+  public static final String REFRESH_PERIOD_AFTER_SHUTDOWN = REFRESH + "/period/afterShutdown";
+  public static final String REFRESH_PERIOD_INACTIVE = REFRESH + "/period/inActive";
   public static final String TYRES = "tyres";
   public static final String TYRES_FRONT_LEFT_PRESSURE = TYRES + "/frontLeftPressure";
   public static final String TYRES_FRONT_RIGHT_PRESSURE = TYRES + "/frontRightPressure";

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/RefreshMode.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/RefreshMode.java
@@ -1,0 +1,26 @@
+package net.heberling.ismart.mqtt;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum RefreshMode {
+  FORCE("force"),
+  OFF("off"),
+  PERIODIC("periodic");
+
+  private String refreshMode;
+
+  private RefreshMode(String refreshMode) {
+    this.refreshMode = refreshMode;
+  }
+
+  public String getStringValue() {
+    return refreshMode;
+  }
+
+  public static Optional<RefreshMode> get(String refreshMode) {
+    return Arrays.stream(RefreshMode.values())
+        .filter(value -> value.getStringValue().equals(refreshMode))
+        .findFirst();
+  }
+}

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/SaicMqttGateway.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/SaicMqttGateway.java
@@ -161,13 +161,6 @@ public class SaicMqttGateway implements Callable<Integer> {
       split = ",")
   private Map<String, String> vinAbrpTokenMap = new HashMap<>();
 
-  @CommandLine.Option(
-      names = {"-i", "--polling-interval"},
-      required = false,
-      description = {"Polling Interval in seconds between SAIC API requests"},
-      defaultValue = "${env:POLLING_INTERVAL:-${config.polling.interval}}")
-  private long pollingInterval = 0;
-
   private IMqttClient client;
 
   private final Map<String, VehicleHandler> vehicleHandlerMap = new HashMap<>();
@@ -229,6 +222,7 @@ public class SaicMqttGateway implements Callable<Integer> {
       var mqttAccountPrefix = "saic/" + saicUser;
 
       client.subscribe(mqttAccountPrefix + "/vehicles/+/+/+/set");
+      client.subscribe(mqttAccountPrefix + "/vehicles/+/+/+/+/set");
 
       MessageCoder<MP_UserLoggingInReq> loginRequestMessageCoder =
           new MessageCoder<>(MP_UserLoggingInReq.class);
@@ -277,8 +271,7 @@ public class SaicMqttGateway implements Callable<Integer> {
                             loginResponseMessage.getBody().getUid(),
                             loginResponseMessage.getApplicationData().getToken(),
                             mqttAccountPrefix,
-                            vin,
-                            pollingInterval);
+                            vin);
                     vehicleHandlerMap.put(vin.getVin(), handler);
                     return handler;
                   })

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/SaicMqttGateway.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/SaicMqttGateway.java
@@ -161,6 +161,13 @@ public class SaicMqttGateway implements Callable<Integer> {
       split = ",")
   private Map<String, String> vinAbrpTokenMap = new HashMap<>();
 
+  @CommandLine.Option(
+      names = {"-i", "--polling-interval"},
+      required = false,
+      description = {"Polling Interval in seconds between SAIC API requests"},
+      defaultValue = "${env:POLLING_INTERVAL:-${config.polling.interval}}")
+  private long pollingInterval = 0;
+
   private IMqttClient client;
 
   private final Map<String, VehicleHandler> vehicleHandlerMap = new HashMap<>();
@@ -270,7 +277,8 @@ public class SaicMqttGateway implements Callable<Integer> {
                             loginResponseMessage.getBody().getUid(),
                             loginResponseMessage.getApplicationData().getToken(),
                             mqttAccountPrefix,
-                            vin);
+                            vin,
+                            pollingInterval);
                     vehicleHandlerMap.put(vin.getVin(), handler);
                     return handler;
                   })

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -44,6 +44,8 @@ public class VehicleHandler {
 
   private final VehicleState vehicleState;
 
+  private final long pollingInterval;
+
   public VehicleHandler(
       SaicMqttGateway saicMqttGateway,
       IMqttClient client,
@@ -51,7 +53,8 @@ public class VehicleHandler {
       String uid,
       String token,
       String mqttAccountPrefix,
-      VinInfo vinInfo) {
+      VinInfo vinInfo,
+      long pollingInterval) {
 
     this.saicMqttGateway = saicMqttGateway;
     this.client = client;
@@ -61,6 +64,7 @@ public class VehicleHandler {
     this.mqttVINPrefix = mqttAccountPrefix + "/" + VEHICLES + "/" + vinInfo.getVin();
     this.vinInfo = vinInfo;
     this.vehicleState = new VehicleState(client, mqttVINPrefix);
+    this.pollingInterval = pollingInterval;
   }
 
   void handleVehicle() throws MqttException, IOException {
@@ -85,6 +89,12 @@ public class VehicleHandler {
           msg.setQos(0);
           msg.setRetained(true);
           client.publish(mqttVINPrefix + "/" + INTERNAL_ABRP, msg);
+
+          try {
+            Thread.sleep(pollingInterval * 1000);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
         }
       } else {
         try {

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -427,7 +427,7 @@ public class VehicleHandler {
             throw new MqttGatewayException("Error setting value for payload: " + message);
           }
           break;
-        case REFRESH_PERIOD_AFTER_SHUTDOWN:
+        case REFRESH_PERIOD_INACTIVE_GRACE:
           try {
             long value = Long.valueOf(message.toString());
             vehicleState.setRefreshPeriodAfterShutdown(value);

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -72,6 +72,9 @@ public class VehicleHandler {
         LOGGER.info("Refreshing vehicle status...");
         OTA_RVMVehicleStatusResp25857 vehicleStatus =
             updateVehicleStatus(uid, token, vinInfo.getVin());
+        if (vehicleStatus == null) {
+          continue; // TODO find better solution for this...
+        }
         OTA_ChrgMangDataResp chargeStatus = updateChargeStatus(uid, token, vinInfo.getVin());
 
         final String abrpApiKey = saicMqttGateway.getAbrpApiKey();
@@ -86,12 +89,6 @@ public class VehicleHandler {
           msg.setQos(0);
           msg.setRetained(true);
           client.publish(mqttVINPrefix + "/" + INTERNAL_ABRP, msg);
-
-          try {
-            Thread.sleep(vehicleState.getRefreshPeriodActive() * 1000);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
         }
       } else {
         try {

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -428,6 +428,14 @@ public class VehicleHandler {
             throw new MqttGatewayException("Error setting value for payload: " + message);
           }
           break;
+        case "refresh/period/afterShutdown":
+          try {
+            long value = Long.valueOf(message.toString());
+            vehicleState.setRefreshPeriodAfterShutdown(value);
+          } catch (NumberFormatException e) {
+            throw new MqttGatewayException("Error setting value for payload: " + message);
+          }
+          break;
         default:
           throw new MqttGatewayException("Unsupported topic " + topic);
       }

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -89,6 +89,8 @@ public class VehicleHandler {
           msg.setQos(0);
           msg.setRetained(true);
           client.publish(mqttVINPrefix + "/" + INTERNAL_ABRP, msg);
+          vehicleState.resetApiUpdateError();
+          vehicleState.markSuccessfulRefresh();
         }
       } else {
         try {
@@ -141,6 +143,7 @@ public class VehicleHandler {
             new String(
                 vehicleStatusResponseMessage.getBody().getErrorMessage(),
                 StandardCharsets.UTF_8)); // try again next time
+        vehicleState.apiUpdateError();
         return null;
       }
 
@@ -168,7 +171,6 @@ public class VehicleHandler {
     }
 
     vehicleState.handleVehicleStatusMessage(vehicleStatusResponseMessage);
-
     return vehicleStatusResponseMessage.getApplicationData();
   }
 
@@ -219,6 +221,7 @@ public class VehicleHandler {
             new String(
                 chargingStatusResponseMessage.getBody().getErrorMessage(),
                 StandardCharsets.UTF_8)); // try again next time
+        vehicleState.apiUpdateError();
         return null;
       }
 

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -135,10 +135,15 @@ public class VehicleHandler {
     while (vehicleStatusResponseMessage.getApplicationData() == null) {
 
       if (vehicleStatusResponseMessage.getBody().isErrorMessagePresent()) {
+
         if (vehicleStatusResponseMessage.getBody().getResult() == 2) {
           // TODO: relogn
         }
-        LOGGER.warn("Refreshing Vehicle State from SAIC API failed..."); // try again next time
+        LOGGER.warn(
+            "Refreshing Vehicle State from SAIC API failed with message {}...",
+            new String(
+                vehicleStatusResponseMessage.getBody().getErrorMessage(),
+                StandardCharsets.UTF_8)); // try again next time
         return null;
       }
 
@@ -212,7 +217,11 @@ public class VehicleHandler {
         if (chargingStatusResponseMessage.getBody().getResult() == 2) {
           // TODO: relogn
         }
-        // try again next time
+        LOGGER.warn(
+            "Refreshing Charging State from SAIC API failed with message {}...",
+            new String(
+                chargingStatusResponseMessage.getBody().getErrorMessage(),
+                StandardCharsets.UTF_8)); // try again next time
         return null;
       }
 

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -406,7 +406,7 @@ public class VehicleHandler {
               throw new MqttGatewayException("Unsupported payload " + message);
           }
           break;
-        case "refresh/mode":
+        case REFRESH_MODE:
           RefreshMode.get(message.toString())
               .ifPresentOrElse(
                   vehicleState::setRefreshMode,
@@ -414,7 +414,7 @@ public class VehicleHandler {
                     throw new MqttGatewayException("Unsupported payload " + message);
                   });
           break;
-        case "refresh/period/active":
+        case REFRESH_PERIOD_ACTIVE:
           try {
             long value = Long.valueOf(message.toString());
             vehicleState.setRefreshPeriodActive(value);
@@ -422,7 +422,7 @@ public class VehicleHandler {
             throw new MqttGatewayException("Error setting value for payload: " + message);
           }
           break;
-        case "refresh/period/inActive":
+        case REFRESH_PERIOD_INACTIVE:
           try {
             long value = Long.valueOf(message.toString());
             vehicleState.setRefreshPeriodInactive(value);
@@ -430,7 +430,7 @@ public class VehicleHandler {
             throw new MqttGatewayException("Error setting value for payload: " + message);
           }
           break;
-        case "refresh/period/afterShutdown":
+        case REFRESH_PERIOD_AFTER_SHUTDOWN:
           try {
             long value = Long.valueOf(message.toString());
             vehicleState.setRefreshPeriodAfterShutdown(value);

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -69,6 +69,7 @@ public class VehicleHandler {
     vehicleState.notifyCarActivityTime(ZonedDateTime.now(), true);
     while (true) {
       if (vehicleState.shouldRefresh()) {
+        LOGGER.info("Refreshing vehicle status...");
         OTA_RVMVehicleStatusResp25857 vehicleStatus =
             updateVehicleStatus(uid, token, vinInfo.getVin());
         OTA_ChrgMangDataResp chargeStatus = updateChargeStatus(uid, token, vinInfo.getVin());
@@ -137,7 +138,7 @@ public class VehicleHandler {
         if (vehicleStatusResponseMessage.getBody().getResult() == 2) {
           // TODO: relogn
         }
-        // try again next time
+        LOGGER.warn("Refreshing Vehicle State from SAIC API failed..."); // try again next time
         return null;
       }
 

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleHandler.java
@@ -88,7 +88,6 @@ public class VehicleHandler {
             msg.setQos(0);
             msg.setRetained(true);
             client.publish(mqttVINPrefix + "/" + INTERNAL_ABRP, msg);
-            vehicleState.resetApiUpdateError();
             vehicleState.markSuccessfulRefresh();
             LOGGER.info("Refreshing vehicle status succeeded...");
           }
@@ -143,7 +142,6 @@ public class VehicleHandler {
           // TODO: relogn
         }
 
-        vehicleState.apiUpdateError();
         throw new MqttGatewayException(
             "Refreshing Vehicle State from SAIC API failed with message: "
                 + new String(
@@ -219,7 +217,6 @@ public class VehicleHandler {
         if (chargingStatusResponseMessage.getBody().getResult() == 2) {
           // TODO: relogn
         }
-        vehicleState.apiUpdateError();
         throw new MqttGatewayException(
             "Refreshing Charging State from SAIC API failed with message: "
                 + new String(

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -1,6 +1,7 @@
 package net.heberling.ismart.mqtt;
 
 import static net.heberling.ismart.mqtt.MqttGatewayTopics.*;
+import static net.heberling.ismart.mqtt.RefreshMode.FORCE;
 import static net.heberling.ismart.mqtt.RefreshMode.PERIODIC;
 
 import java.nio.charset.StandardCharsets;
@@ -506,6 +507,10 @@ public class VehicleState {
         return true;
       case PERIODIC:
       default:
+        if (previousRefreshMode == FORCE) {
+          previousRefreshMode = null;
+          return true;
+        }
         if (lastSuccessfulRefresh == null) {
           markSuccessfulRefresh();
           return true;

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -621,7 +621,7 @@ public class VehicleState {
             String.valueOf(refreshPeriodAfterShutdown).getBytes(StandardCharsets.UTF_8));
     try {
       mqttMessage.setRetained(true);
-      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_PERIOD_AFTER_SHUTDOWN, mqttMessage);
+      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_PERIOD_INACTIVE_GRACE, mqttMessage);
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -37,7 +37,6 @@ public class VehicleState {
   private long refreshPeriodAfterShutdown;
   private RefreshMode refreshMode;
   private RefreshMode previousRefreshMode;
-  private int apiUpdateError;
 
   public VehicleState(IMqttClient client, String mqttVINPrefix) {
     this(client, mqttVINPrefix, () -> Clock.systemDefaultZone());
@@ -493,7 +492,6 @@ public class VehicleState {
       msg.setRetained(true);
       client.publish(mqttVINPrefix + "/" + INFO_LAST_MESSAGE, msg);
       lastVehicleMessage = message.getMessageTime();
-      resetApiUpdateError();
     }
     // something happened, better check the vehicle state
     notifyCarActivityTime(message.getMessageTime(), false);
@@ -514,9 +512,6 @@ public class VehicleState {
         }
         if (lastCarActivity.isAfter(lastSuccessfulRefresh)) {
           return true;
-        }
-        if (apiUpdateError > 10) {
-          return false;
         }
         if (hvBatteryActive
             || lastCarShutdown
@@ -614,18 +609,6 @@ public class VehicleState {
 
   public RefreshMode getRefreshMode() {
     return this.refreshMode;
-  }
-
-  public void apiUpdateError() {
-    this.apiUpdateError++;
-  }
-
-  public void resetApiUpdateError() {
-    this.apiUpdateError = 0;
-  }
-
-  public int getApiUpdateError() {
-    return apiUpdateError;
   }
 
   public void markSuccessfulRefresh() {

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -497,9 +497,13 @@ public class VehicleState {
         return true;
       case PERIODIC:
       default:
-        return hvBatteryActive
-            || lastCarActivity.isBefore(
-                ZonedDateTime.now().minus(refreshPeriodInactive, ChronoUnit.SECONDS));
+        if (hvBatteryActive) {
+          return lastCarActivity.isBefore(
+              ZonedDateTime.now().minus(refreshPeriodActive, ChronoUnit.SECONDS));
+        } else {
+          return lastCarActivity.isBefore(
+              ZonedDateTime.now().minus(refreshPeriodInactive, ChronoUnit.SECONDS));
+        }
     }
   }
 

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -15,9 +15,12 @@ import net.heberling.ismart.asn1.v3_0.entity.OTA_ChrgMangDataResp;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class VehicleState {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(VehicleState.class);
   private final IMqttClient client;
   private final String mqttVINPrefix;
 
@@ -494,7 +497,7 @@ public class VehicleState {
       case PERIODIC:
       default:
         return hvBatteryActive
-            || lastCarActivity.isAfter(
+            || lastCarActivity.isBefore(
                 ZonedDateTime.now().minus(refreshPeriodInactive, ChronoUnit.SECONDS));
     }
   }
@@ -567,6 +570,7 @@ public class VehicleState {
     MqttMessage mqttMessage =
         new MqttMessage(refreshMode.getStringValue().getBytes(StandardCharsets.UTF_8));
     try {
+      LOGGER.info("Setting refresh mode to {}", refreshMode.getStringValue());
       mqttMessage.setRetained(true);
       this.client.publish(this.mqttVINPrefix + "/refresh/mode", mqttMessage);
     } catch (MqttException e) {

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -34,6 +34,7 @@ public class VehicleState {
   private long refreshPeriodInactive;
 
   private RefreshMode refreshMode;
+  private RefreshMode previousRefreshMode;
 
   public VehicleState(IMqttClient client, String mqttVINPrefix) {
     this.client = client;
@@ -492,7 +493,7 @@ public class VehicleState {
       case OFF:
         return false;
       case FORCE:
-        setRefreshMode(PERIODIC);
+        setRefreshMode(previousRefreshMode);
         return true;
       case PERIODIC:
       default:
@@ -576,7 +577,7 @@ public class VehicleState {
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }
-
+    this.previousRefreshMode = this.refreshMode;
     this.refreshMode = refreshMode;
   }
 

--- a/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
+++ b/saic-java-mqtt-gateway/src/main/java/net/heberling/ismart/mqtt/VehicleState.java
@@ -575,7 +575,7 @@ public class VehicleState {
         new MqttMessage(String.valueOf(refreshPeriodActive).getBytes(StandardCharsets.UTF_8));
     try {
       mqttMessage.setRetained(true);
-      this.client.publish(this.mqttVINPrefix + "/refresh/period/active", mqttMessage);
+      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_PERIOD_ACTIVE, mqttMessage);
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }
@@ -591,7 +591,7 @@ public class VehicleState {
         new MqttMessage(String.valueOf(refreshPeriodInactive).getBytes(StandardCharsets.UTF_8));
     try {
       mqttMessage.setRetained(true);
-      this.client.publish(this.mqttVINPrefix + "/refresh/period/inActive", mqttMessage);
+      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_PERIOD_INACTIVE, mqttMessage);
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }
@@ -604,7 +604,7 @@ public class VehicleState {
     try {
       LOGGER.info("Setting refresh mode to {}", refreshMode.getStringValue());
       mqttMessage.setRetained(true);
-      this.client.publish(this.mqttVINPrefix + "/refresh/mode", mqttMessage);
+      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_MODE, mqttMessage);
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }
@@ -638,7 +638,7 @@ public class VehicleState {
             String.valueOf(refreshPeriodAfterShutdown).getBytes(StandardCharsets.UTF_8));
     try {
       mqttMessage.setRetained(true);
-      this.client.publish(this.mqttVINPrefix + "/refresh/period/afterShutdown", mqttMessage);
+      this.client.publish(this.mqttVINPrefix + "/" + REFRESH_PERIOD_AFTER_SHUTDOWN, mqttMessage);
     } catch (MqttException e) {
       throw new MqttGatewayException("Error publishing message: " + mqttMessage, e);
     }

--- a/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
+++ b/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
@@ -1,0 +1,99 @@
+package net.heberling.ismart.mqtt;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class VehicleStateTest {
+
+  public static final int REFERENCE_TIME = 1684273208;
+  @Mock private MqttClient mqttClient;
+
+  private Clock clock;
+  private VehicleState vehicleState;
+
+  @BeforeEach
+  public void setUp() throws MqttException {
+    clock = Clock.fixed(Instant.ofEpochSecond(REFERENCE_TIME), ZoneId.systemDefault());
+    vehicleState = new VehicleState(mqttClient, "test", () -> this.clock);
+    vehicleState.notifyCarActivityTime(ZonedDateTime.now(clock), true);
+  }
+
+  @Test
+  public void willAllwaysRefreshOnFirstCall() {
+    assertThat(vehicleState.shouldRefresh(), is(true));
+  }
+
+  @Test
+  public void willRefreshIfCarWasActiveAfterLastRefresh() throws MqttException {
+    clock = Clock.offset(clock, java.time.Duration.ofSeconds(60));
+    vehicleState.notifyCarActivityTime(ZonedDateTime.now(clock), true);
+    assertThat(vehicleState.shouldRefresh(), is(true));
+  }
+
+  @Test
+  public void willNotRefreshIfApiReturns10SubsequentErrors() throws MqttException {
+    clock = Clock.offset(clock, java.time.Duration.ofSeconds(60));
+    vehicleState.markSuccessfulRefresh();
+    for (int i = 0; i < 10; i++) {
+      vehicleState.apiUpdateError();
+    }
+    assertThat(vehicleState.shouldRefresh(), is(false));
+  }
+
+  @Test
+  public void willNeverRefreshIfRefreshModeIsOff() throws MqttException {
+    clock = Clock.offset(clock, java.time.Duration.ofSeconds(60));
+    vehicleState.setRefreshMode(RefreshMode.OFF);
+    assertThat(vehicleState.shouldRefresh(), is(false));
+  }
+
+  @Test
+  public void willRefreshIfRefreshModeIsForce() {
+    vehicleState.setRefreshMode(RefreshMode.FORCE);
+    assertThat(vehicleState.shouldRefresh(), is(true));
+    assertThat(vehicleState.getRefreshMode(), is(RefreshMode.PERIODIC));
+  }
+
+  @Test
+  public void willNotRefreshIfActiveBefore30s() throws MqttException {
+    vehicleState.markSuccessfulRefresh();
+    clock = Clock.offset(clock, java.time.Duration.ofSeconds(29));
+    assertThat(vehicleState.shouldRefresh(), is(false));
+  }
+
+  @Test
+  public void willRefreshIfActiveAfter30s() throws MqttException {
+    vehicleState.markSuccessfulRefresh();
+    clock = Clock.offset(clock, java.time.Duration.ofSeconds(31));
+    assertThat(vehicleState.shouldRefresh(), is(true));
+  }
+
+  @Test
+  public void willNotRefreshIfInactiveBefore1Day() throws MqttException {
+    vehicleState.markSuccessfulRefresh();
+    vehicleState.setHVBatteryActive(false);
+    clock = Clock.offset(clock, java.time.Duration.ofDays(1).minusSeconds(1));
+    assertThat(vehicleState.shouldRefresh(), is(false));
+  }
+
+  @Test
+  public void willRefreshIfInactiveAfter1Day() throws MqttException {
+    vehicleState.markSuccessfulRefresh();
+    vehicleState.setHVBatteryActive(false);
+    clock = Clock.offset(clock, java.time.Duration.ofDays(1).plusSeconds(1));
+    assertThat(vehicleState.shouldRefresh(), is(true));
+  }
+}

--- a/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
+++ b/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
@@ -58,6 +58,20 @@ public class VehicleStateTest {
   }
 
   @Test
+  public void willRefreshTwiceIfRefreshModeIsForce() throws MqttException {
+    vehicleState.markSuccessfulRefresh();
+    vehicleState.setHVBatteryActive(false);
+    clock = Clock.offset(clock, java.time.Duration.ofDays(1).minusSeconds(1));
+    vehicleState.setRefreshMode(RefreshMode.FORCE);
+    assertThat(vehicleState.shouldRefresh(), is(true));
+    assertThat(vehicleState.getRefreshMode(), is(RefreshMode.PERIODIC));
+    assertThat(vehicleState.shouldRefresh(), is(true));
+    assertThat(vehicleState.getRefreshMode(), is(RefreshMode.PERIODIC));
+    assertThat(vehicleState.shouldRefresh(), is(false));
+    assertThat(vehicleState.getRefreshMode(), is(RefreshMode.PERIODIC));
+  }
+
+  @Test
   public void willNotRefreshIfActiveBefore30s() throws MqttException {
     vehicleState.markSuccessfulRefresh();
     clock = Clock.offset(clock, java.time.Duration.ofSeconds(29));

--- a/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
+++ b/saic-java-mqtt-gateway/src/test/java/net/heberling/ismart/mqtt/VehicleStateTest.java
@@ -44,16 +44,6 @@ public class VehicleStateTest {
   }
 
   @Test
-  public void willNotRefreshIfApiReturns10SubsequentErrors() throws MqttException {
-    clock = Clock.offset(clock, java.time.Duration.ofSeconds(60));
-    vehicleState.markSuccessfulRefresh();
-    for (int i = 0; i < 10; i++) {
-      vehicleState.apiUpdateError();
-    }
-    assertThat(vehicleState.shouldRefresh(), is(false));
-  }
-
-  @Test
   public void willNeverRefreshIfRefreshModeIsOff() throws MqttException {
     clock = Clock.offset(clock, java.time.Duration.ofSeconds(60));
     vehicleState.setRefreshMode(RefreshMode.OFF);


### PR DESCRIPTION
Idea: avoid sending too much data over the network. Setting a polling interval will reduce traffic, normally 30 seconds resolution should be enough. 

Ideas: 
* set a value > 0 as default, however this changes current behavior, maybe expectations of certain users.
* limit the value to a maximum. Is there any risk of the car becoming unresponsive while HV battery is active? Maybe setting too high values (like 10 minutes) kills the purpose of the gateway?
